### PR TITLE
feat: add auth to bluetooth subsystem

### DIFF
--- a/src/bluetooth/infrastructure.c
+++ b/src/bluetooth/infrastructure.c
@@ -6,11 +6,12 @@
  */
 
 #include "userinterface/screens/blepairing/blepairing.h"
+#include "zephyr/bluetooth/conn.h"
 #include <zephyr/settings/settings.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_REGISTER(ZephyrWatch_BLE, LOG_LEVEL_DBG);
+LOG_MODULE_REGISTER(ZephyrWatch_BLE, LOG_LEVEL_INF);
 
 static const struct bt_data m_ad[] = {
     BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
@@ -21,7 +22,16 @@ static const struct bt_data m_sd[] = {
     BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
 
-static void m_connected_callback(struct bt_conn *conn, uint8_t err) {
+static void start_advertisement() {
+    const int err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, m_ad, ARRAY_SIZE(m_ad), m_sd, ARRAY_SIZE(m_sd));
+    if (err) {
+        LOG_DBG("Advertising failed to start (err %d).", err);
+        return;
+    }
+    LOG_DBG("Advertising successfully started.");
+}
+
+static void process_connection(struct bt_conn *conn, uint8_t err) {
     if (err) LOG_ERR("Connection failed (err %u).", err);
     else {
         char addr[BT_ADDR_LE_STR_LEN];
@@ -30,13 +40,14 @@ static void m_connected_callback(struct bt_conn *conn, uint8_t err) {
     }
 }
 
-static void m_disconnected_callback(struct bt_conn *conn, uint8_t reason) {
+static void process_disconnection(struct bt_conn *conn, uint8_t reason) {
     LOG_INF("Disconnected (reason 0x%02x).", reason);
 }
 
-BT_CONN_CB_DEFINE(conn_callbacks) = {
-    .connected = m_connected_callback,
-    .disconnected = m_disconnected_callback,
+BT_CONN_CB_DEFINE(connection_callbacks) = {
+    .connected = process_connection,
+    .disconnected = process_disconnection,
+    .recycled = start_advertisement,
 };
 
 char* passkey_to_string(const unsigned int passkey) {
@@ -45,36 +56,51 @@ char* passkey_to_string(const unsigned int passkey) {
     return passkey_str;
 }
 
-static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey){
+static void process_passkey_display(struct bt_conn *conn, unsigned int passkey){
     char addr[BT_ADDR_LE_STR_LEN] = {0};
     // Write PIN to the screen.
     blepairing_screen_init();
     blepairing_screen_set_pin(passkey_to_string(passkey));
-    LOG_INF("Displaying passkey on the screen.");
-
-    // Create a smooth slide transition from right to left
-    blepairing_screen_load(false);
+    blepairing_screen_load();
+    LOG_DBG("Displaying passkey on the screen.");
 
     bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-    LOG_DBG("Passkey for %s: %06u\n", addr, passkey);
+    LOG_DBG("Passkey for %s: %06u", addr, passkey);
 }
 
-static void auth_cancel(struct bt_conn *conn){
+static void process_auth_cancel(struct bt_conn *conn){
     char addr[BT_ADDR_LE_STR_LEN];
     bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-    LOG_DBG("Pairing cancelled: %s\n", addr);
+    LOG_DBG("Pairing cancelled: %s", addr);
+    blepairing_screen_unload();
 }
 
-static struct bt_conn_auth_cb auth_cb_display = {
-    .passkey_display = auth_passkey_display,
+static void process_pairing_complete(struct bt_conn *conn, bool bonded) {
+    LOG_DBG("Pairing complete. Bonded: %s", bonded ? "OK" : "FAILURE");
+    blepairing_screen_unload();
+}
+
+static void process_pairing_failed(struct bt_conn *conn, enum bt_security_err reason) {
+    LOG_DBG("Pairing failed. Reason: 0x%02x", reason);
+    bt_conn_disconnect(conn, BT_HCI_ERR_AUTH_FAIL);
+    blepairing_screen_unload();
+}
+
+static struct bt_conn_auth_info_cb auth_info_callbacks = {
+    .pairing_complete = process_pairing_complete,
+    .pairing_failed = process_pairing_failed,
+};
+
+static struct bt_conn_auth_cb auth_callbacks = {
+    .passkey_display = process_passkey_display,
     .passkey_entry = NULL,
-    .cancel = auth_cancel,
+    .cancel = process_auth_cancel,
 };
 
 /* The API function to enable Bluetooth and start advertisement. */
 uint8_t enable_bluetooth_subsystem() {
     int err;
-    
+
     err = bt_enable(NULL);
     if (err) {
         LOG_ERR("Bluetooth init failed (err %d).", err);
@@ -82,24 +108,31 @@ uint8_t enable_bluetooth_subsystem() {
     }
     LOG_DBG("Bluetooth initialized.");
 
+    err = bt_unpair(BT_ID_DEFAULT, BT_ADDR_LE_ANY);
+    if (err) {
+        LOG_ERR("Unpairing failed (err %d).", err);
+    }
+    LOG_DBG("Unpairing successful.");
+
     if (IS_ENABLED(CONFIG_SETTINGS)) {
         settings_load();
     }
 
-    err = bt_conn_auth_cb_register(&auth_cb_display);
+    err = bt_conn_auth_cb_register(&auth_callbacks);
     if (err) {
-        LOG_ERR("Failed to register authentication callback (err %d).", err);
+        LOG_ERR("Failed to register authentication callbacks (err %d).", err);
         return err;
     }
     LOG_DBG("Authentication callback registered successfully.");
 
-    err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, m_ad, ARRAY_SIZE(m_ad), m_sd, ARRAY_SIZE(m_sd));
+    err = bt_conn_auth_info_cb_register(&auth_info_callbacks);
     if (err) {
-        LOG_ERR("Advertising failed to start (err %d).", err);
+        LOG_ERR("Failed to register authentication information callbacks (err %d).", err);
         return err;
     }
+    LOG_DBG("Authentication information callback registered successfully.");
 
-    LOG_DBG("Advertising successfully started.");
+    start_advertisement();
     return 0;
 }
 
@@ -111,7 +144,6 @@ uint8_t disable_bluetooth_subsystem() {
         LOG_ERR("Advertising failed to stop (err %d).", err);
         return err;
     }
-
     LOG_DBG("Advertising successfully stopped.");
 
     err = bt_disable();
@@ -119,7 +151,6 @@ uint8_t disable_bluetooth_subsystem() {
         LOG_ERR("Bluetooth failed to disable (err %d).", err);
         return err;
     }
-
     LOG_DBG("Bluetooth disabled.");
     return 0;
 }

--- a/src/bluetooth/infrastructure.c
+++ b/src/bluetooth/infrastructure.c
@@ -5,11 +5,12 @@
  * @maintainer: electricalgorithm @ github 
  */
 
+#include "userinterface/screens/blepairing/blepairing.h"
 #include <zephyr/settings/settings.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_REGISTER(ZephyrWatch_BLE, LOG_LEVEL_INF);
+LOG_MODULE_REGISTER(ZephyrWatch_BLE, LOG_LEVEL_DBG);
 
 static const struct bt_data m_ad[] = {
     BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
@@ -38,6 +39,38 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
     .disconnected = m_disconnected_callback,
 };
 
+char* passkey_to_string(const unsigned int passkey) {
+    static char passkey_str[7];
+    snprintf(passkey_str, sizeof(passkey_str), "%06u", passkey);
+    return passkey_str;
+}
+
+static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey){
+    char addr[BT_ADDR_LE_STR_LEN] = {0};
+    // Write PIN to the screen.
+    blepairing_screen_init();
+    blepairing_screen_set_pin(passkey_to_string(passkey));
+    LOG_INF("Displaying passkey on the screen.");
+
+    // Create a smooth slide transition from right to left
+    blepairing_screen_load(false);
+
+    bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+    LOG_DBG("Passkey for %s: %06u\n", addr, passkey);
+}
+
+static void auth_cancel(struct bt_conn *conn){
+    char addr[BT_ADDR_LE_STR_LEN];
+    bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+    LOG_DBG("Pairing cancelled: %s\n", addr);
+}
+
+static struct bt_conn_auth_cb auth_cb_display = {
+    .passkey_display = auth_passkey_display,
+    .passkey_entry = NULL,
+    .cancel = auth_cancel,
+};
+
 /* The API function to enable Bluetooth and start advertisement. */
 uint8_t enable_bluetooth_subsystem() {
     int err;
@@ -47,12 +80,18 @@ uint8_t enable_bluetooth_subsystem() {
         LOG_ERR("Bluetooth init failed (err %d).", err);
         return err;
     }
-
     LOG_DBG("Bluetooth initialized.");
 
     if (IS_ENABLED(CONFIG_SETTINGS)) {
         settings_load();
     }
+
+    err = bt_conn_auth_cb_register(&auth_cb_display);
+    if (err) {
+        LOG_ERR("Failed to register authentication callback (err %d).", err);
+        return err;
+    }
+    LOG_DBG("Authentication callback registered successfully.");
 
     err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, m_ad, ARRAY_SIZE(m_ad), m_sd, ARRAY_SIZE(m_sd));
     if (err) {

--- a/src/bluetooth/services/current_time_service.c
+++ b/src/bluetooth/services/current_time_service.c
@@ -63,6 +63,6 @@ BT_GATT_SERVICE_DEFINE(cts_cvs,
     BT_GATT_CHARACTERISTIC(
         BT_UUID_CTS_CURRENT_TIME,
         BT_GATT_CHRC_WRITE,
-        BT_GATT_PERM_WRITE,
+        BT_GATT_PERM_WRITE_ENCRYPT | BT_GATT_PERM_WRITE_AUTHEN,
         NULL, m_time_write_callback, dummy_data),
 );

--- a/src/bluetooth/services/current_time_service.h
+++ b/src/bluetooth/services/current_time_service.h
@@ -15,7 +15,6 @@ extern "C" {
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/bluetooth/gatt.h>
-#include "datetime/datetime.h"
 
 /* A function to trigger UI updates - to be implemented in main.c */
 extern void trigger_ui_update();

--- a/src/userinterface/screens/blepairing/blepairing.c
+++ b/src/userinterface/screens/blepairing/blepairing.c
@@ -1,0 +1,202 @@
+/** BLE Pairing/Bonding Screen Implementation.
+ * Provides functionality to display a 6-digit PIN code for Bluetooth pairing/bonding.
+ * Features a modern, visually appealing design with animated elements.
+ *
+ * @license GNU v3
+ * @maintainer electricalgorithm @ github
+ */
+
+#include <zephyr/logging/log.h>
+#include <string.h>
+#include "lvgl.h"
+#include "userinterface/utils.h"
+#include "userinterface/screens/home/home.h"
+#include "userinterface/screens/blepairing/blepairing.h"
+
+// Create a logger.
+LOG_MODULE_REGISTER(ZephyrWatch_UI_BLEPairing, LOG_LEVEL_DBG);
+
+// Forward declarations for static functions
+static void render_title_label(lv_obj_t *flex_element);
+static void render_instruction_label(lv_obj_t *flex_element);
+static void render_pin_display(lv_obj_t *flex_element);
+static void render_footer_label(lv_obj_t *flex_element);
+
+// Holds the BLE pairing screen objects.
+lv_obj_t *blepairing_screen;
+static lv_obj_t *label_title;
+static lv_obj_t *label_instruction;
+static lv_obj_t *pin_container;
+static lv_obj_t *pin_digits[6];  // Array to hold individual PIN digit labels
+static lv_obj_t *label_footer;
+
+// Current PIN code (default for demonstration)
+static char current_pin[7] = "123456";
+
+void blepairing_screen_event(lv_event_t * event) {
+    lv_event_code_t event_code = lv_event_get_code(event);
+    LOG_DBG("Event code: %d", event_code);
+
+    // Handle double click to return to home.
+    if (event_code == LV_EVENT_DOUBLE_CLICKED) {
+        LOG_DBG("Double click detected: returning to home screen.");
+        if (!lv_obj_is_valid(home_screen)) {
+            home_screen_init();
+        }
+        lv_screen_load_anim(home_screen, LV_SCR_LOAD_ANIM_FADE_OUT, 300, 0, true);
+    }
+}
+
+void blepairing_screen_init() {
+    LOG_DBG("Initializing BLE pairing screen");
+
+    // Create the screen object which is the LV object with no parent.
+    blepairing_screen = create_screen();
+
+    // Create main vertical layout container
+    lv_obj_t *main_column = create_column(blepairing_screen, 100, 100);
+    lv_obj_set_style_pad_all(main_column, 10, LV_PART_MAIN);
+    lv_obj_set_style_pad_row(main_column, 3, LV_PART_MAIN);
+
+    // Create rows for different sections
+    lv_obj_t *title_row = create_row(main_column, 100, 15);
+    lv_obj_t *instruction_row = create_row(main_column, 100, 15);
+    lv_obj_t *pin_row = create_row(main_column, 100, 40);
+    lv_obj_t *footer_row = create_row(main_column, 100, 15);
+
+    // Render all components
+    render_title_label(title_row);
+    render_instruction_label(instruction_row);
+    render_pin_display(pin_row);
+    render_footer_label(footer_row);
+
+    // Add event handler for gestures
+    lv_obj_add_event_cb(blepairing_screen, blepairing_screen_event, LV_EVENT_ALL, NULL);
+    LOG_DBG("BLE pairing screen initialized successfully.");
+}
+
+static void render_title_label(lv_obj_t *flex_element) {
+    label_title = lv_label_create(flex_element);
+    lv_label_set_text(label_title, "Pairing Request");
+
+    // Center the title
+    lv_obj_set_width(label_title, LV_SIZE_CONTENT);
+    lv_obj_set_height(label_title, LV_SIZE_CONTENT);
+    lv_obj_set_align(label_title, LV_ALIGN_CENTER);
+
+    // Style the title
+    lv_obj_set_style_text_color(label_title, lv_color_white(), LV_PART_MAIN);
+    lv_obj_set_style_text_font(label_title, &lv_font_montserrat_18, LV_PART_MAIN);
+    lv_obj_center(label_title);
+}
+
+static void render_instruction_label(lv_obj_t *flex_element) {
+    label_instruction = lv_label_create(flex_element);
+    lv_label_set_text(label_instruction, "Enter PIN on your device.");
+
+    // Center the instruction
+    lv_obj_set_width(label_instruction, LV_SIZE_CONTENT);
+    lv_obj_set_height(label_instruction, LV_SIZE_CONTENT);
+    lv_obj_set_align(label_instruction, LV_ALIGN_CENTER);
+
+    // Style the instruction
+    lv_obj_set_style_text_align(label_instruction, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_text_font(label_instruction, &lv_font_montserrat_14, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_text_color(label_instruction, lv_color_white(), LV_PART_MAIN | LV_STATE_DEFAULT);
+}
+
+static void render_pin_display(lv_obj_t *flex_element) {
+    // Create a container for the PIN digits with horizontal layout
+    pin_container = lv_obj_create(flex_element);
+    lv_obj_set_size(pin_container, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
+    lv_obj_set_align(pin_container, LV_ALIGN_CENTER);
+
+    // Configure flexbox layout for PIN container
+    lv_obj_set_layout(pin_container, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(pin_container, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(pin_container, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_column(pin_container, 8, LV_PART_MAIN);
+    lv_obj_set_style_pad_all(pin_container, 15, LV_PART_MAIN);
+
+    // Remove background and border from container
+    lv_obj_set_style_bg_opa(pin_container, LV_OPA_TRANSP, LV_PART_MAIN);
+    lv_obj_set_style_border_opa(pin_container, LV_OPA_TRANSP, LV_PART_MAIN);
+    
+    // Create individual digit displays
+    for (int i = 0; i < 6; i++) {
+        // Create a container for each digit
+        lv_obj_t *digit_box = lv_obj_create(pin_container);
+        lv_obj_set_size(digit_box, 25, 45);
+
+        // Style the digit box with rounded corners and shadow
+        lv_obj_set_style_radius(digit_box, 8, LV_PART_MAIN);
+        lv_obj_set_style_bg_color(digit_box, lv_color_hex(0x404040), LV_PART_MAIN);
+        lv_obj_set_style_bg_opa(digit_box, LV_OPA_100, LV_PART_MAIN);
+        lv_obj_set_style_border_color(digit_box, lv_color_hex(0x555555), LV_PART_MAIN);
+        lv_obj_set_style_border_width(digit_box, 2, LV_PART_MAIN);
+        lv_obj_set_style_border_opa(digit_box, LV_OPA_50, LV_PART_MAIN);
+
+        // Create the digit label
+        pin_digits[i] = lv_label_create(digit_box);
+        lv_label_set_text_fmt(pin_digits[i], "%c", current_pin[i]);
+
+        // Center the digit in its box
+        lv_obj_set_align(pin_digits[i], LV_ALIGN_CENTER);
+
+        // Style the digit text
+        lv_obj_set_style_text_font(pin_digits[i], &lv_font_montserrat_14, LV_PART_MAIN | LV_STATE_DEFAULT);
+        lv_obj_set_style_text_color(pin_digits[i], lv_color_white(), LV_PART_MAIN | LV_STATE_DEFAULT);
+        lv_obj_set_style_text_align(pin_digits[i], LV_TEXT_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+}
+
+static void render_footer_label(lv_obj_t *flex_element) {
+    label_footer = lv_label_create(flex_element);
+    lv_label_set_text(label_footer, "Double tap to cancel");
+
+    // Center the footer
+    lv_obj_set_width(label_footer, LV_SIZE_CONTENT);
+    lv_obj_set_height(label_footer, LV_SIZE_CONTENT);
+    lv_obj_set_align(label_footer, LV_ALIGN_CENTER);
+
+    // Style the footer
+    lv_obj_set_style_text_align(label_footer, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_text_font(label_footer, &lv_font_montserrat_14, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_text_color(label_footer, lv_color_white(), LV_PART_MAIN | LV_STATE_DEFAULT);
+}
+
+uint8_t blepairing_screen_set_pin(const char *pin_code) {
+    // Validate input
+    if (pin_code == NULL || strlen(pin_code) != 6) {
+        LOG_ERR("Invalid PIN code provided");
+        return 1;
+    }
+
+    // Check if PIN digits are valid
+    for (int i = 0; i < 6; i++) {
+        if (pin_digits[i] == NULL) {
+            LOG_ERR("PIN digit %d is NULL", i);
+            return 1;
+        }
+    }
+    // Update the PIN code
+    strncpy(current_pin, pin_code, 6);
+    current_pin[6] = '\0';
+    // Update each digit display
+    for (int i = 0; i < 6; i++) {
+        lv_label_set_text_fmt(pin_digits[i], "%c", current_pin[i]);
+    }
+    // Update the display
+    lv_disp_flush_ready(lv_disp_get_default());
+    LOG_DBG("PIN code updated to: %s", current_pin);
+    return 0;
+}
+
+void blepairing_screen_load(bool kill_previous) {
+    if (!lv_obj_is_valid(blepairing_screen)) {
+        blepairing_screen_init();
+    }
+    // Go back to home screen with slide down animation.
+    // Do not delete the screen since register_application will generate new items.
+    lv_screen_load_anim(blepairing_screen, LV_SCR_LOAD_ANIM_FADE_IN, 300, 0, kill_previous);
+}

--- a/src/userinterface/screens/blepairing/blepairing.c
+++ b/src/userinterface/screens/blepairing/blepairing.c
@@ -10,11 +10,10 @@
 #include <string.h>
 #include "lvgl.h"
 #include "userinterface/utils.h"
-#include "userinterface/screens/home/home.h"
 #include "userinterface/screens/blepairing/blepairing.h"
 
 // Create a logger.
-LOG_MODULE_REGISTER(ZephyrWatch_UI_BLEPairing, LOG_LEVEL_DBG);
+LOG_MODULE_REGISTER(ZephyrWatch_UI_BLEPairing, LOG_LEVEL_INF);
 
 // Forward declarations for static functions
 static void render_title_label(lv_obj_t *flex_element);
@@ -24,6 +23,7 @@ static void render_footer_label(lv_obj_t *flex_element);
 
 // Holds the BLE pairing screen objects.
 lv_obj_t *blepairing_screen;
+lv_obj_t *previous_screen;
 static lv_obj_t *label_title;
 static lv_obj_t *label_instruction;
 static lv_obj_t *pin_container;
@@ -31,19 +31,15 @@ static lv_obj_t *pin_digits[6];  // Array to hold individual PIN digit labels
 static lv_obj_t *label_footer;
 
 // Current PIN code (default for demonstration)
-static char current_pin[7] = "123456";
+static char current_pin[7] = "000000";
 
 void blepairing_screen_event(lv_event_t * event) {
     lv_event_code_t event_code = lv_event_get_code(event);
-    LOG_DBG("Event code: %d", event_code);
 
     // Handle double click to return to home.
     if (event_code == LV_EVENT_DOUBLE_CLICKED) {
-        LOG_DBG("Double click detected: returning to home screen.");
-        if (!lv_obj_is_valid(home_screen)) {
-            home_screen_init();
-        }
-        lv_screen_load_anim(home_screen, LV_SCR_LOAD_ANIM_FADE_OUT, 300, 0, true);
+        LOG_DBG("Double click detected: returning to previous screen.");
+        blepairing_screen_unload();
     }
 }
 
@@ -192,11 +188,17 @@ uint8_t blepairing_screen_set_pin(const char *pin_code) {
     return 0;
 }
 
-void blepairing_screen_load(bool kill_previous) {
+void blepairing_screen_load() {
+    // Save the previous screen to unload afterwards.
+    previous_screen = lv_scr_act();
     if (!lv_obj_is_valid(blepairing_screen)) {
         blepairing_screen_init();
     }
-    // Go back to home screen with slide down animation.
-    // Do not delete the screen since register_application will generate new items.
-    lv_screen_load_anim(blepairing_screen, LV_SCR_LOAD_ANIM_FADE_IN, 300, 0, kill_previous);
+    // Load the BLE pairing screen with animation.
+    lv_screen_load_anim(blepairing_screen, LV_SCR_LOAD_ANIM_FADE_IN, 300, 0, false);
+}
+
+void blepairing_screen_unload() {
+    // Load the previous screen.
+    lv_screen_load_anim(previous_screen, LV_SCR_LOAD_ANIM_FADE_OUT, 300, 0, true);
 }

--- a/src/userinterface/screens/blepairing/blepairing.h
+++ b/src/userinterface/screens/blepairing/blepairing.h
@@ -21,6 +21,16 @@ extern lv_obj_t *blepairing_screen;
 /* The init implementation for the BLE Pairing screen. */
 void blepairing_screen_init();
 
+/** Load the BLE pairing screen.
+ * @return void
+ */
+void blepairing_screen_load();
+
+/** Unload the BLE pairing screen. 
+ * @return void
+ */
+void blepairing_screen_unload();
+
 /** Event handler for BLE screen gestures.
  * @param event The event object containing gesture details.
  * @return void
@@ -32,13 +42,6 @@ void blepairing_screen_event(lv_event_t * event);
  * @return 0 on success, 1 on failure.
  */
 uint8_t blepairing_screen_set_pin(const char *pin_code);
-
-
-/** Load the BLE pairing screen.
- * @param kill_previous A boolean indicating whether to close the previous screen before loading the BLE pairing screen.
- * @return void
- */
-void blepairing_screen_load(bool kill_previous);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/userinterface/screens/blepairing/blepairing.h
+++ b/src/userinterface/screens/blepairing/blepairing.h
@@ -1,0 +1,47 @@
+/** BLE Pairing/Bonding Interface.
+ * Provides functionality to show an PIN code through UI.
+ * This PIN code is used in connecting client device.
+ *
+ * @license GNU v3
+ * @maintainer electricalgorithm @ github
+ */
+
+#ifndef _UI_SCREENS_BLEPAIRING_H
+#define _UI_SCREENS_BLEPAIRING_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "lvgl.h"
+
+/* The screen object to be used in the userinterface. */
+extern lv_obj_t *blepairing_screen;
+
+/* The init implementation for the BLE Pairing screen. */
+void blepairing_screen_init();
+
+/** Event handler for BLE screen gestures.
+ * @param event The event object containing gesture details.
+ * @return void
+ */
+void blepairing_screen_event(lv_event_t * event);
+
+/** Set the PIN code to be displayed on the BLE pairing screen.
+ * @param pin_code A 6-character string representing the PIN code.
+ * @return 0 on success, 1 on failure.
+ */
+uint8_t blepairing_screen_set_pin(const char *pin_code);
+
+
+/** Load the BLE pairing screen.
+ * @param kill_previous A boolean indicating whether to close the previous screen before loading the BLE pairing screen.
+ * @return void
+ */
+void blepairing_screen_load(bool kill_previous);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif


### PR DESCRIPTION
Within this patch, we force authentication on client side and show the pairing pin. This is still in WIP since there is no possibility to return to home screen after successful/failure on the process.

Somehow touches the Issue: #13 since it will require auth callbacks.
Solves #27 